### PR TITLE
Use jq to escape message into JSON payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The only required configuration is the Samson URL, available from the Project "W
 steps:
   - label: ":rocket: Deploy with Samson"
     plugins:
-      - envato/samson-deploy#v0.0.1:
+      - envato/samson-deploy#v0.1.1:
           url: "https://example.com/integrations/buildkite/578dc36a28ab49b2998603f0475211c3"
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -13,21 +13,26 @@ fi
 headers=( "-H" "HTTP_X_BUILDKITE_EVENT: build.finished" "-H" "Content-Type: application/json")
 message=$(echo $BUILDKITE_MESSAGE | tr '\r\n' ' ')
 
-payload=$(cat <<EOF
-{
+payload=$(jq -n --arg id "$BUILDKITE_BUILD_ID" \
+  --arg url "$BUILDKITE_BUILD_URL" \
+  --arg message "$BUILDKITE_MESSAGE" \
+  --arg num "$BUILDKITE_BUILD_NUMBER" \
+  --arg commit "$BUILDKITE_COMMIT" \
+  --arg branch "$BUILDKITE_BRANCH" \
+  --arg source "$BUILDKITE_SOURCE" '{
   "event": "build.finished",
   "build": {
-    "id": "$BUILDKITE_BUILD_ID",
+    "id": $id,
     "url": "UNIMPLEMENTED",
-    "web_url": "$BUILDKITE_BUILD_URL",
-    "number": $BUILDKITE_BUILD_NUMBER,
+    "web_url": $url,
+    "number": $num | tonumber,
     "state": "passed",
     "blocked": false,
-    "message": "$message",
-    "commit": "$BUILDKITE_COMMIT",
-    "branch": "$BUILDKITE_BRANCH",
+    "message": $message,
+    "commit": $commit,
+    "branch": $branch,
     "tag": null,
-    "source": "$BUILDKITE_SOURCE",
+    "source": $source,
     "creator": null,
     "created_at": "1970-01-01 00:00:00 UTC",
     "scheduled_at": "1970-01-01 00:00:00 UTC",
@@ -38,9 +43,7 @@ payload=$(cat <<EOF
   },
   "pipeline": {},
   "sender": null
-}
-EOF
-)
+}')
 
 curl --fail \
     --request POST \

--- a/hooks/command
+++ b/hooks/command
@@ -11,7 +11,6 @@ if [[ "${BUILDKITE_PLUGIN_SAMSON_DEPLOY_DEBUG:-false}" =~ (true|on|1) ]] ; then
 fi
 
 headers=( "-H" "HTTP_X_BUILDKITE_EVENT: build.finished" "-H" "Content-Type: application/json")
-message=$(echo $BUILDKITE_MESSAGE | tr '\r\n' ' ')
 
 payload=$(jq -n --arg id "$BUILDKITE_BUILD_ID" \
   --arg url "$BUILDKITE_BUILD_URL" \

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,5 +1,8 @@
 #!/usr/bin/env bats
 
+# Upstream PR to add this to the container https://github.com/buildkite-plugins/buildkite-plugin-tester/pull/25
+apk --no-cache add jq
+
 load "$BATS_PATH/load.bash"
 
 # Uncomment to enable stub debugging


### PR DESCRIPTION
Trying to escape characters in Bash is not fun. This is a lot more robust.
In order to avoid stubbing out jq and not getting a good integration test, we install it locally in the container