### PR TITLE
Improve feedback from the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The only required configuration is the Samson URL, available from the Project "W
 steps:
   - label: ":rocket: Deploy with Samson"
     plugins:
-      - envato/samson-deploy#v0.1.1:
+      - envato/samson-deploy#v0.1.2:
           url: "https://example.com/integrations/buildkite/578dc36a28ab49b2998603f0475211c3"
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -44,10 +44,37 @@ payload=$(jq -n --arg id "$BUILDKITE_BUILD_ID" \
   "sender": null
 }')
 
-curl --fail \
-    --request POST \
+tmpdir="$(mktemp -d)"
+code=$(curl --request POST \
     --silent \
-    --show-error \
+    -o "$tmpdir/samson_output" \
+    -w "%{http_code}" \
     "${headers[@]}" \
     -d "${payload}" \
-    "$url"
+    "$url")
+
+case "$code" in
+  2*)
+    ret=0
+    ;;
+  4*)
+    ret=1
+    ;;
+  5*)
+    ret=2
+    ;;
+  *)
+    ret=3
+    ;;
+esac
+
+if [[ $ret != 0 ]] ; then
+  echo "+++ Samson submission"
+  echo "HTTP code: $code"
+  cat "$tmpdir/samson_output"
+  echo
+  exit $ret
+else
+  echo "--- Samson submission"
+  echo "HTTP code: $code"
+fi


### PR DESCRIPTION
Print the curl output on non-2xx responses.
Include the http response code in the output.
Test the new functionality.